### PR TITLE
drop deprecated 3.0, add stable 3.2 and 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        couchdb: [latest, "3.1", "3.0", "2.3"]
+        couchdb: [latest, "3.3", "3.2", "3.1", "2.3"]
 
     steps:
       - name: Clone Repository

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        couchdb: ["3.1", "3.0", "2.3"]
+        couchdb: ["3.3", "3.2", "3.1", "2.3"]
 
     steps:
       - name: Git checkout

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   couchdb-version:
-    description: CouchDB version to use (default "3.1.0")
+    description: CouchDB version to use (default "3.3.2")
     required: false
-    default: 3.1.0
+    default: 3.3.2
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,8 @@ if [[ -z "$COUCHDB_VERSION" ]]; then
   exit 2
 fi
 
-if [[ $COUCHDB_VERSION != "latest" && $COUCHDB_VERSION != "3.1.0" && $COUCHDB_VERSION != "3.1" && $COUCHDB_VERSION != "3" && $COUCHDB_VERSION != "3.0.1" && $COUCHDB_VERSION != "3.0" && $COUCHDB_VERSION != "2.3.1" && $COUCHDB_VERSION != "2.3" && $COUCHDB_VERSION != "2" ]]; then
-  echo "$$COUCHDB_VERSION should be one of latest, 3.1.0, 3.1, 3, 3.0.1, 3.0, 2.3.1, 2.3 and 2"
+if [[ $COUCHDB_VERSION != "latest" && $COUCHDB_VERSION != "3.3.2" && $COUCHDB_VERSION != "3.3" && $COUCHDB_VERSION != "3.2.3" && $COUCHDB_VERSION != "3.2" && $COUCHDB_VERSION != "3.1.2" && $COUCHDB_VERSION != "3.1" && $COUCHDB_VERSION != "3" && $COUCHDB_VERSION != "2.3.1" && $COUCHDB_VERSION != "2.3" && $COUCHDB_VERSION != "2" ]]; then
+  echo "$$COUCHDB_VERSION should be one of latest, 3.3.2, 3.3, 3.2.3, 3.2, 3.1.2, 3.1, 3, 2.3.1, 2.3 and 2"
   exit 2
 fi
 


### PR DESCRIPTION
As the title implies:
align with current releases